### PR TITLE
Add support to mock thirdparty methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "Pretend"
 uuid = "8ad1c615-040c-41b0-a18f-ae9e9fd09b5b"
 authors = ["Tom Kwong <tk3369@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-julia = "1.1"
 ExprTools = "0.1"
+MacroTools = "0.5"
+julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 [![codecov.io](http://codecov.io/github/tk3369/Pretend.jl/coverage.svg?branch=master)](http://codecov.io/github/tk3369/Pretend.jl?branch=master)
 ![Project Status](https://img.shields.io/badge/status-experimental-red)
 
-Pretend is a mocking library.
+Pretend is a mocking library. The main idea is that you can annotate any functions
+as `@mockable`.  Then, you can easily stub out calls to the function with your
+own patch using `apply`.  You must activate the framework using `Pretend.activate`;
+otherwise, patches will not be applied (for performance reasons).
 
 ## Motivation
+
+The following examples demonstrate the basic usage of the Pretend framework.
 
 ```julia
 # Annotate any function with @mockable macro
@@ -30,6 +35,13 @@ end
 spy() do
     foo()
     @test called_exactly_once(bar, 1, 2)
+end
+
+# Mocking thirdparty methods!
+@mockable Base.sin(x::Real)
+fakesin(x::Real) = 10
+apply(sin => fakesin) do
+    @test sin(1.0) == 10
 end
 ```
 

--- a/examples/observers.jl
+++ b/examples/observers.jl
@@ -1,0 +1,51 @@
+# An observer pattern example
+# See a similar example at https://easymock.org/getting-started.html
+
+using Pretend
+Pretend.activate()
+
+using BinaryTraits
+using BinaryTraits.Prefix: Can
+
+using Test
+
+# Formal interface
+@trait HandleNewDocument
+@implement Can{HandleNewDocument} by document_added(_, document)
+
+# A ProofReader can handle any new documents
+struct ProofReader end
+document_added(reader::ProofReader, document) = println("notified document_added => $document")
+
+# We will claim that it satisfies the HandleNewDocument trait
+@assign ProofReader with Can{HandleNewDocument}
+@check ProofReader
+
+# A DocumentManager deals with all documentation needs
+struct DocumentManager
+    listeners::Vector
+end
+
+# Add a new document to the system
+# 1. persist the document
+# 2. notify any collaborator that might be interested about this event
+function add(dm::DocumentManager, title, content)
+    println("added doc '$title' with content '$content'")
+    foreach(x -> document_added(x, title), dm.listeners)
+end
+
+reader = ProofReader()
+dm = DocumentManager([reader])
+
+# just a check
+add(dm, "Life is boring", "Really? I don't think so.")
+
+# Annotate the mockable function
+@mockable document_added(reader::ProofReader, document) = println("notified document_added => $document")
+
+# Create a mock(patch)
+apply(document_added => (reader::ProofReader, document) -> println("mocked! ha!")) do
+    add(dm, "Life is boring", "Really? I don't think so.")
+    @test called_exactly_once(document_added, reader, "Life is boring")
+end
+

--- a/src/Pretend.jl
+++ b/src/Pretend.jl
@@ -2,6 +2,7 @@ module Pretend
 
 using Base: Callable
 using ExprTools: splitdef, combinedef
+using MacroTools: postwalk, rmlines
 
 export @mockable
 export apply, spy

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -1,7 +1,7 @@
 """
     activated()
 
-Returns true if the mocking framework is enabled. The default setting is OFF so
+Returns true if the Pretend framework is enabled. The default setting is OFF so
 that the mocking code is optimized aways by the compiler.
 """
 activated() = false
@@ -9,9 +9,14 @@ activated() = false
 """
     activate()
 
-Activate the mocking framework. Use this at the beginning of the test suite.
+Activate the Pretend framework. Normally, it is called at the beginning of a test script.
 """
-function activate()
-    @eval activated() = true
-    return nothing
-end
+activate() = @eval(activated() = true)
+
+"""
+    deactivate()
+
+Deactivate the Pretend framework. It is not commonly used because it is already the
+default setting.
+"""
+deactivate() = @eval(activated() = false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,5 @@ Pretend.activate()
     include("test_basic.jl")
     include("test_spy.jl")
     include("test_misc.jl")
+    include("test_3rdparty.jl")
 end

--- a/test/test_3rdparty.jl
+++ b/test/test_3rdparty.jl
@@ -1,0 +1,18 @@
+module ThirdPartyMock
+    using Pretend, Test
+    Pretend.activate()
+
+    @mockable Base.sin(x::Real)
+
+    fakesin(x::Real) = 10
+
+    function test()
+        apply(sin => fakesin) do
+            @test sin(1.0) == 10
+        end
+        @test sin(1.0) ≈ 0.8414709848078965
+    end
+end
+
+using .ThirdPartyMock
+ThirdPartyMock.test()


### PR DESCRIPTION
Couple changes in this PR:
- `delegate_method`: derive a mockable local function that delegates to the 3rd party one
- `delegate_function_body`: make a delegate expression out of the call signature
- `base_symbol`: strip away module prefix
- `deactivate`: deactivate framework (good for dev/test purpose)