### PR TITLE
Have find return early if store is empty

### DIFF
--- a/src/patchstore.jl
+++ b/src/patchstore.jl
@@ -8,6 +8,7 @@ default_patch_store() = PATCHES
 Find a patch from the `store` given the argument types.
 """
 function find(store::PatchStore, args...)
+    isempty(store.dct) && return nothing
     @debug "finding patch" dctkeys=collect(keys(store.dct))[1] args
     patch = get(store.dct, args, nothing)
     patch !== nothing && @debug "found patch" store.dct patch


### PR DESCRIPTION
The debug statement


```
    @debug "finding patch" dctkeys=collect(keys(store.dct))[1] args
```

will error if the store is empty. Returning early should fix this behavior.